### PR TITLE
Added uninstall, refactored to use Install-ChocolateyZipPackage

### DIFF
--- a/packages/TeamCityAgent/TeamCityAgent.nuspec
+++ b/packages/TeamCityAgent/TeamCityAgent.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>TeamCityAgent</id>
-        <version>2.0.1-beta-04</version>
+        <version>2.0.1-beta-05</version>
         <title>TeamCity Build Agent</title>
         <authors>JetBrains</authors>
         <owners>maartenba;jetbrains</owners>

--- a/packages/TeamCityAgent/tools/chocolateyInstall.ps1
+++ b/packages/TeamCityAgent/tools/chocolateyInstall.ps1
@@ -40,9 +40,6 @@ $agentDrive = split-path $agentDir -qualifier
 $parameters.GetEnumerator() | % { "$($_.Name)=$($_.Value)" } | Write-Verbose
 $parameters.GetEnumerator() | % { "$($_.Name)=$($_.Value)" } | Out-File "$toolsDir/install-parameters.txt" -Encoding ascii
 
-## Temporary folder
-#$tempFolder = $env:TEMP
-
 $packageArgs = @{
   packageName   = "$packageName"
   unzipLocation = "$agentDir"
@@ -65,7 +62,7 @@ function Get-PropsDictFromJavaPropsFile ($configFile) {
                                 -and (($_.Contains('=')))){
                                     $props = @()
                                     $props = $_.split('=',2)
-                                    # Don't write anything to standard out or it messes up the return
+                                    # Use Write-Host or Write-Verbose, Write-Output appends to the return value and breaks things
                                     Write-Verbose "Props are $props"
                                     $configProps.add($props[0],$props[1])
                             }

--- a/packages/TeamCityAgent/tools/chocolateyInstall.ps1
+++ b/packages/TeamCityAgent/tools/chocolateyInstall.ps1
@@ -1,3 +1,6 @@
+
+$ErrorActionPreference = 'Stop'; # stop on all errors
+
 if ($env:chocolateyPackageParameters -eq $null) {
 	throw "No parameters have been passed into Chocolatey install, e.g. -params 'serverUrl=http://... agentName=... agentDir=...'"
 }
@@ -22,6 +25,9 @@ if ($parameters["ownPort"] -eq $null) {
     Write-Host No agent port is specified. Defaulting to $parameters["ownPort"]
 }
 
+$packageName = "TeamCityAgent"
+$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
 ## Make local variables of it
 $serverUrl = $parameters["serverUrl"];
 $agentDir = $parameters["agentDir"];
@@ -29,83 +35,87 @@ $agentName = $parameters["agentName"];
 $ownPort = $parameters["ownPort"];
 $agentDrive = split-path $agentDir -qualifier
 
+# Write out the install parameters to a file for reference during upgrade/uninstall
+# This doesn't currently preserve anything during an upgrade, it just helps locate the service control batch files
+$parameters.GetEnumerator() | % { "$($_.Name)=$($_.Value)" } | Write-Verbose
+$parameters.GetEnumerator() | % { "$($_.Name)=$($_.Value)" } | Out-File "$toolsDir/install-parameters.txt" -Encoding ascii
+
 ## Temporary folder
-$tempFolder = $env:TEMP
+#$tempFolder = $env:TEMP
 
-## Download from TeamCity server
-Get-ChocolateyWebFile 'buildAgent.zip' "$tempFolder\buildAgent.zip" "$serverUrl/update/buildAgent.zip"
-
-## Extract
-New-Item -ItemType Directory -Force -Path $agentDir
-Get-ChocolateyUnzip "$tempFolder\buildAgent.zip" $agentDir  
-
-## Clean up
-#del /Q "$tempFolder\buildAgent.zip"
-
-# Configure agent
-copy $agentDir\conf\buildAgent.dist.properties $agentDir\conf\buildAgent.properties
-# ConvertFrom-StringData equivalent to longer format but loses key ordering (both strip comments)
-#$buildAgentProps = convertfrom-stringdata (Get-Content $agentDir\conf\buildAgent.properties | Out-String)
-$buildAgentProps = [ordered]@{}
-$buildAgentConfig = get-content $agentDir\conf\buildAgent.properties
-if ($ownPort -eq "9090") {
-# Simply replace config elements sinnce we aren't adding any new entries
-$buildAgentConfig | Foreach-Object {
-    $_ -replace 'serverUrl=(?:\S+)', "serverUrl=$serverUrl" `
-	   -replace 'name=(?:\S+)', "name=$agentName"
-    } | Set-Content $agentDir\conf\buildAgent.properties
-} else {
-# Rewrite the entire config since we are adding a new element and this can be tricky to get right
-# The 'if' block lines strip comments to avoid invalid/duplicate key issues
-$buildAgentConfig | %{if (`
-                            (!($_.StartsWith('#'))) `
-                                -and (!($_.StartsWith(';')))`
-                                -and (!($_.StartsWith(";")))`
-                                -and (!($_.StartsWith('`')))`
-                                -and (($_.Contains('=')))){
-                                    $buildAgentProps.add($_.split('=',2)[0],$_.split('=',2)[1])
-                                }
-                    }
-
-Write-Verbose "Build Agent original settings"
-$buildAgentProps.GetEnumerator() | % { "$($_.Name)=$($_.Value)" } | Write-Verbose
-
-$buildAgentProps['serverUrl'] = $serverUrl
-$buildAgentProps['name'] = $agentName
-$buildAgentProps['ownPort'] = $ownPort
-# Write out the keys seen
-Write-Verbose "Build Agent updated settings"
-$buildAgentProps.GetEnumerator() | % { "$($_.Name)=$($_.Value)" } | Write-Verbose
-$buildAgentProps.GetEnumerator() | % { "$($_.Name)=$($_.Value)" } | Out-File $agentDir\conf\buildAgent.properties
+$packageArgs = @{
+  packageName   = "$packageName"
+  unzipLocation = "$agentDir"
+  url           = "$serverUrl/update/buildAgent.zip"
 }
+Install-ChocolateyZipPackage @packageArgs
 
-# Configure service wrapper to allow multiple instances on a single machine
-# This rewrites the wrapper config file without comments, if you need the comments, don't supply the agentName when installing to get the default config
-if (-Not ($defaultName -eq $true)) {
-    $wrapperProps = [ordered]@{}
-    $wrapperConf = get-content $agentDir\launcher\conf\wrapper.conf 
-    $wrapperConf | %{if (`
+# Generic function to read Java properties file into ordered dict
+function Get-PropsDictFromJavaPropsFile ($configFile) {
+    # Returns configProps ordered dict
+    $config = Get-Content $configFile
+    Write-Verbose "$config"
+    $configProps = [ordered]@{}
+    # The 'if' block lines strip comments to avoid invalid/duplicate key issues
+    $config | %{if (`
                             (!($_.StartsWith('#')))`
                                 -and (!($_.StartsWith(';')))`
                                 -and (!($_.StartsWith(";")))`
                                 -and (!($_.StartsWith('`')))`
                                 -and (($_.Contains('=')))){
-                                    $wrapperProps.add($_.split('=',2)[0],$_.split('=',2)[1])
+                                    $props = @()
+                                    $props = $_.split('=',2)
+                                    # Don't write anything to standard out or it messes up the return
+                                    Write-Verbose "Props are $props"
+                                    $configProps.add($props[0],$props[1])
                             }
                     }
+    return $configProps
+}
+
+# Configure agent
+$buildAgentDistFile = "$agentDir\conf\buildAgent.dist.properties"
+$buildAgentPropFile = "$agentDir\conf\buildAgent.properties"
+
+if ($ownPort -eq "9090") {
+# Simply replace config elements since we aren't adding any new entries
+(Get-Content $buildAgentDistFile) | Foreach-Object {
+    $_ -replace 'serverUrl=(?:\S+)', "serverUrl=$serverUrl" `
+       -replace 'name=(?:\S+)', "name=$agentName"
+    } | Set-Content $buildAgentPropFile
+} else {
+    # Since we are adding a new element and this can be tricky to get right
+    # this rewrites the entire config without comments and updated values
+    $buildAgentProps = Get-PropsDictFromJavaPropsFile $buildAgentDistFile
+
+    Write-Verbose "Build Agent original settings"
+    $buildAgentProps.GetEnumerator() | % { "$($_.Name)=$($_.Value)" } | Write-Verbose
+
+    # Set values that require customization
+    $buildAgentProps['serverUrl'] = $serverUrl
+    $buildAgentProps['name'] = $agentName
+    $buildAgentProps['ownPort'] = $ownPort
+
+    Write-Verbose "Build Agent updated settings"
+    $buildAgentProps.GetEnumerator() | % { "$($_.Name)=$($_.Value)" } | Write-Verbose
+    $buildAgentProps.GetEnumerator() | % { "$($_.Name)=$($_.Value)" } | Out-File $buildAgentPropFile -Encoding 'ascii'
+}
+
+# Supplying a custom agentName allows multiple instances on a single machine
+# This rewrites the wrapper config file without comments, if you need the comments, don't supply an agentName when installing to get the default config
+if (-Not ($defaultName -eq $true)) {
+    $wrapperPropsFile = "$agentDir\launcher\conf\wrapper.conf"
+    $wrapperProps = Get-PropsDictFromJavaPropsFile $wrapperPropsFile
+
     Write-Verbose "Java Service Wrapper original settings"
     $wrapperProps.GetEnumerator() | % { "$($_.Name)=$($_.Value)" } | Write-Verbose
-    # Name of the service
     $wrapperProps['wrapper.ntservice.name'] = "$agentName"
-    # Display name of the service
     $wrapperProps['wrapper.ntservice.displayname'] = "$agentName TeamCity Build Agent"
-    # Description of the service
     $wrapperProps['wrapper.ntservice.description'] = "$agentName TeamCity Build Agent Service"
-    #$wrapperProps['']
-    # Write out the keys seen, can't do it inline because JavaServiceWrapper is picky about encoding
+
     Write-Verbose "Java Service Wrapper updated settings"
     $wrapperProps.GetEnumerator() | % { "$($_.Name)=$($_.Value)" } | Write-Verbose
-    $wrapperProps.GetEnumerator() | % { "$($_.Name)=$($_.Value)" } | Out-File $agentDir\launcher\conf\wrapper.conf -Encoding 'ASCII'
+    $wrapperProps.GetEnumerator() | % { "$($_.Name)=$($_.Value)" } | Out-File $wrapperPropsFile -Encoding 'ascii'
 }
 
 # Future state, catch failure and call chocolateyUninstall.ps1 or some other cleanup

--- a/packages/TeamCityAgent/tools/chocolateybeforemodify.ps1
+++ b/packages/TeamCityAgent/tools/chocolateybeforemodify.ps1
@@ -1,0 +1,35 @@
+﻿
+$ErrorActionPreference = 'Stop' # stop on all errors
+
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+# Don't use ConvertFrom-StringData as it corrupts Windows paths like C:\buildAgent
+function Get-PropsDictFromJavaPropsFile ($configFile) {
+    # Returns configProps ordered dict
+    $config = Get-Content $configFile
+    Write-Verbose "$config"
+    $configProps = [ordered]@{}
+    $config | %{if (`
+                            (!($_.StartsWith('#')))`
+                                -and (!($_.StartsWith(';')))`
+                                -and (!($_.StartsWith(";")))`
+                                -and (!($_.StartsWith('`')))`
+                                -and (($_.Contains('=')))){
+                                    $props = @()
+                                    $props = $_.split('=',2)
+                                    Write-Verbose "Props are $props"
+                                    $configProps.add($props[0],$props[1])
+                            }
+                    }
+    return $configProps
+}
+$installParametersFile = "$toolsDir/install-parameters.txt"
+$installParameters = Get-PropsDictFromJavaPropsFile $installParametersFile
+$installParameters["agentDir"]
+$installParameters["agentName"]
+"InstallParameters are $installParameters"
+$installParameters.GetEnumerator() | % { "$($_.Name)=$($_.Value)" } | Write-Verbose
+$agentDir = $installParameters["agentDir"]
+$agentName = $installParameters["agentName"]
+$agentDir
+$agentDrive = split-path $agentDir -qualifier
+Start-ChocolateyProcessAsAdmin "/C `"$agentDrive && cd /d $agentDir\bin && $agentDir\bin\service.stop.bat && $agentDir\bin\service.uninstall.bat`"" cmd

--- a/packages/TeamCityAgent/tools/chocolateybeforemodify.ps1
+++ b/packages/TeamCityAgent/tools/chocolateybeforemodify.ps1
@@ -24,12 +24,8 @@ function Get-PropsDictFromJavaPropsFile ($configFile) {
 }
 $installParametersFile = "$toolsDir/install-parameters.txt"
 $installParameters = Get-PropsDictFromJavaPropsFile $installParametersFile
-$installParameters["agentDir"]
-$installParameters["agentName"]
-"InstallParameters are $installParameters"
 $installParameters.GetEnumerator() | % { "$($_.Name)=$($_.Value)" } | Write-Verbose
 $agentDir = $installParameters["agentDir"]
 $agentName = $installParameters["agentName"]
-$agentDir
 $agentDrive = split-path $agentDir -qualifier
 Start-ChocolateyProcessAsAdmin "/C `"$agentDrive && cd /d $agentDir\bin && $agentDir\bin\service.stop.bat && $agentDir\bin\service.uninstall.bat`"" cmd

--- a/packages/TeamCityAgent/tools/chocolateyuninstall.ps1
+++ b/packages/TeamCityAgent/tools/chocolateyuninstall.ps1
@@ -1,0 +1,10 @@
+﻿
+$ErrorActionPreference = 'Stop'; # stop on all errors
+
+$packageName = 'TeamCityAgent'
+$zipFileName = 'buildAgent.zip'
+
+$uninstalled = $false
+Uninstall-ChocolateyZipPackage -PackageName $packageName `
+                                -ZipFileName  $zipFileName
+$uninstalled = $true

--- a/packages/TeamCityAgent/tools/chocolateyuninstall.ps1
+++ b/packages/TeamCityAgent/tools/chocolateyuninstall.ps1
@@ -7,4 +7,35 @@ $zipFileName = 'buildAgent.zip'
 $uninstalled = $false
 Uninstall-ChocolateyZipPackage -PackageName $packageName `
                                 -ZipFileName  $zipFileName
+
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+# Don't use ConvertFrom-StringData as it corrupts Windows paths like C:\buildAgent
+function Get-PropsDictFromJavaPropsFile ($configFile) {
+    # Returns configProps ordered dict
+    $config = Get-Content $configFile
+    Write-Verbose "$config"
+    $configProps = [ordered]@{}
+    $config | %{if (`
+                            (!($_.StartsWith('#')))`
+                                -and (!($_.StartsWith(';')))`
+                                -and (!($_.StartsWith(";")))`
+                                -and (!($_.StartsWith('`')))`
+                                -and (($_.Contains('=')))){
+                                    $props = @()
+                                    $props = $_.split('=',2)
+                                    Write-Verbose "Props are $props"
+                                    $configProps.add($props[0],$props[1])
+                            }
+                    }
+    return $configProps
+}
+$installParametersFile = "$toolsDir/install-parameters.txt"
+$installParameters = Get-PropsDictFromJavaPropsFile $installParametersFile
+$installParameters.GetEnumerator() | % { "$($_.Name)=$($_.Value)" } | Write-Verbose
+$agentDir = $installParameters["agentDir"]
+if (Test-Path $agentDir) {
+    "Removing $agentDir"
+    Remove-Item $agentDir -force -recurse
+}
+
 $uninstalled = $true


### PR DESCRIPTION
DRY'ed things up a bit and changed install to use Install-ChocolateyZipPackage which will create a folder under $chocolateyRoot\lib\$packageName for the package to store the "install-parameters.txt" file which allows for uninstalling from the correct location (since there isn't a registry entry or anything like that for zips).