### PR TITLE
Implement workaround for Chocolatey 0.10.14 working directory limitation

### DIFF
--- a/packages/TeamCityAgent/TeamCityAgent.nuspec
+++ b/packages/TeamCityAgent/TeamCityAgent.nuspec
@@ -15,7 +15,7 @@
         <description>TeamCity Build Agent for jetbrains.com/teamcity. It is a piece of software which listens for the commands from the TeamCity server and starts the actual build processes. Install requires at least serverUrl parameter, e.g. -params 'serverurl=http://...', also supported are agentName, agentDir, ownPort and possibly others. If looking to see what changes in the agent config files during the run use -v argument to choco.exe.</description>
         <summary>TeamCity Build Agent for jetbrains.com/teamcity. It is a piece of software which listens for the commands from the TeamCity server and starts the actual build processes. Requires parameters!</summary>
         <copyright>JetBrains s.r.o.</copyright>
-        <releaseNotes>Version 3.x of this package uses AdoptOpenJDK.</releaseNotes>
+        <releaseNotes>Version 3.x of this package uses AdoptOpenJDK. Version 4.x depends on Chocolatey 0.10.14.</releaseNotes>
         <tags>teamcity build agent ci continuous integration admin</tags>
         <dependencies>
             <dependency id="adoptopenjdk" version="8.192.0"/>

--- a/packages/TeamCityAgent/TeamCityAgent.nuspec
+++ b/packages/TeamCityAgent/TeamCityAgent.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>TeamCityAgent</id>
-        <version>3.0.1</version>
+        <version>4.0.0</version>
         <title>TeamCity Build Agent</title>
         <authors>JetBrains</authors>
         <owners>maartenba;jetbrains</owners>

--- a/packages/TeamCityAgent/tools/chocolateyInstall.ps1
+++ b/packages/TeamCityAgent/tools/chocolateyInstall.ps1
@@ -132,7 +132,7 @@ if (-Not ($defaultName -eq $true -And $defaultServiceAccount -eq $true)) {
 }
 
 # TODO: catch failure and call chocolateyUninstall.ps1 or some other cleanup
-Set-Location $agentDir\bin
-Start-ChocolateyProcessAsAdmin "Start-Process -FilePath .\service.install.bat -Wait"
+$workingDirectory = Join-Path $agentDir "bin"
+Start-ChocolateyProcessAsAdmin "Set-Location $workingDirectory; Start-Process -FilePath .\service.install.bat -Wait"
 Sleep 2
-Start-ChocolateyProcessAsAdmin "Start-Process -FilePath .\service.start.bat -Wait"
+Start-ChocolateyProcessAsAdmin "Set-Location $workingDirectory; Start-Process -FilePath .\service.start.bat -Wait"

--- a/packages/TeamCityAgent/tools/chocolateybeforemodify.ps1
+++ b/packages/TeamCityAgent/tools/chocolateybeforemodify.ps1
@@ -29,7 +29,7 @@ $agentDir = $installParameters["agentDir"]
 $agentName = $installParameters["agentName"]
 $agentDrive = split-path $agentDir -qualifier
 
-Set-Location $agentDir\bin
-Start-ChocolateyProcessAsAdmin "Start-Process -FilePath .\service.stop.bat -Wait"
+$workingDirectory = Join-Path $agentDir "bin"
+Start-ChocolateyProcessAsAdmin "Set-Location $workingDirectory; Start-Process -FilePath .\service.stop.bat -Wait"
 Sleep 2
-Start-ChocolateyProcessAsAdmin "Start-Process -FilePath .\service.uninstall.bat -Wait"
+Start-ChocolateyProcessAsAdmin "Set-Location $workingDirectory; Start-Process -FilePath .\service.uninstall.bat -Wait"


### PR DESCRIPTION
Resovles #30 

This moves the `Set-Location` to within the `Start-ChocolateyProcessAsAdmin` block so the encoded command which Chocolatey generates contains the correct location path and relative path for the teamcity agent batch files.

The existing code will cause `Start-ChocolateyProcessAsAdmin` to generate the following code

```powershell
$noSleep = $False
#$env:ChocolateyEnvironmentDebug='false'
#$env:ChocolateyEnvironmentVerbose='false'
& import-module -name 'C:\ProgramData\chocolatey\helpers\chocolateyInstaller.psm1' -Verbose:$false | Out-Null;
try {
    $progressPreference="SilentlyContinue"
	
    Start-Process -FilePath .\service.install.bat -Wait
    if(!$noSleep) { start-sleep 6 }
}
catch {
    if(!$noSleep) { start-sleep 8 }
    throw
}
```

This pull request will result in the following changes, the comment will not be included and is only for reviewers of this pull request to see what's new.
```powershell
$noSleep = $False
#$env:ChocolateyEnvironmentDebug='false'
#$env:ChocolateyEnvironmentVerbose='false'
& import-module -name 'C:\ProgramData\chocolatey\helpers\chocolateyInstaller.psm1' -Verbose:$false | Out-Null;
try {
    $progressPreference="SilentlyContinue"
	
    # Assuming that $agentDir is C:\buildAgent
    Set-Location "C:\buildAgent\bin"; Start-Process -FilePath .\service.install.bat -Wait
    if(!$noSleep) { start-sleep 6 }
}
catch {
    if(!$noSleep) { start-sleep 8 }
    throw
}
```

Should this change increment the package version in the nuspec definition?