### PR TITLE
Additional Config Paths & Service User Bug Fix

### DIFF
--- a/packages/TeamCityAgent/tools/chocolateyInstall.ps1
+++ b/packages/TeamCityAgent/tools/chocolateyInstall.ps1
@@ -69,6 +69,15 @@ $serviceAccount = $parameters["serviceAccount"];
 $serviceAccountPassword = $parameters["serviceAccountPassword"];
 $agentDrive = split-path $agentDir -qualifier
 
+if($serviceAccount -ne $null)
+{
+    if($serviceAccount -notlike "*\*")
+    {
+        Write-Verbose "Service account has no '\' assuming local user"
+        $serviceAccount = ".\$serviceAccount"
+    }
+}
+
 # Write out the install parameters to a file for reference during upgrade/uninstall
 # This doesn't currently preserve anything during an upgrade, it just helps locate the service control batch files
 $parameters.GetEnumerator() | % { "$($_.Name)=$($_.Value)" } | Write-Verbose

--- a/packages/TeamCityAgent/tools/chocolateyInstall.ps1
+++ b/packages/TeamCityAgent/tools/chocolateyInstall.ps1
@@ -18,17 +18,20 @@ if ($parameters["agentDir"] -eq $null) {
 }
 
 if ($parameters["agentWorkDir"] -eq $null) {
-    $parameters["agentWorkDir"] = "$env:SystemDrive\buildAgent\work"
+    $agentDir = $parameters["agentDir"];
+    $parameters["agentWorkDir"] = "$agentDir\work"
     Write-Host No agent directory is specified. Defaulting to $parameters["agentWorkDir"]
 }
 
 if ($parameters["agentTempDir"] -eq $null) {
-    $parameters["agentTempDir"] = "$env:SystemDrive\buildAgent\temp"
+    $agentDir = $parameters["agentDir"];
+    $parameters["agentTempDir"] = "$agentDir\temp"
     Write-Host No agent directory is specified. Defaulting to $parameters["agentTempDir"]
 }
 
 if ($parameters["agentSystemDir"] -eq $null) {
-    $parameters["agentSystemDir"] = "$env:SystemDrive\buildAgent\system"
+    $agentDir = $parameters["agentDir"];
+    $parameters["agentSystemDir"] = "$agentDir\system"
     Write-Host No agent directory is specified. Defaulting to $parameters["agentSystemDir"]
 }
 

--- a/packages/TeamCityAgent/tools/chocolateyInstall.ps1
+++ b/packages/TeamCityAgent/tools/chocolateyInstall.ps1
@@ -11,15 +11,33 @@ $parameters = ConvertFrom-StringData -StringData $env:chocolateyPackageParameter
 if ($parameters["serverUrl"] -eq $null) {
     throw "Please specify the TeamCity server URL by passing it as a parameter to Chocolatey install, e.g. -params 'serverUrl=http://...'"
 }
+
 if ($parameters["agentDir"] -eq $null) {
     $parameters["agentDir"] = "$env:SystemDrive\buildAgent"
     Write-Host No agent directory is specified. Defaulting to $parameters["agentDir"]
 }
+
+if ($parameters["agentWorkDir"] -eq $null) {
+    $parameters["agentWorkDir"] = "$env:SystemDrive\buildAgent\work"
+    Write-Host No agent directory is specified. Defaulting to $parameters["agentWorkDir"]
+}
+
+if ($parameters["agentTempDir"] -eq $null) {
+    $parameters["agentTempDir"] = "$env:SystemDrive\buildAgent\temp"
+    Write-Host No agent directory is specified. Defaulting to $parameters["agentTempDir"]
+}
+
+if ($parameters["agentSystemDir"] -eq $null) {
+    $parameters["agentSystemDir"] = "$env:SystemDrive\buildAgent\system"
+    Write-Host No agent directory is specified. Defaulting to $parameters["agentSystemDir"]
+}
+
 if ($parameters["agentName"] -eq $null) {
     $defaultName = $true
     $parameters["agentName"] = "$env:COMPUTERNAME"
     Write-Host No agent name is specified. Defaulting to $parameters["agentName"]
 }
+
 if ($parameters["ownPort"] -eq $null) {
     $parameters["ownPort"] = "9090"
     Write-Host No agent port is specified. Defaulting to $parameters["ownPort"]
@@ -42,6 +60,9 @@ $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 ## Make local variables of it
 $serverUrl = $parameters["serverUrl"];
 $agentDir = $parameters["agentDir"];
+$agentWorkDir = $parameters["agentWorkDir"];
+$agentTempDir = $parameters["agentTempDir"];
+$agentSystemDir = $parameters["agentSystemDir"];
 $agentName = $parameters["agentName"];
 $ownPort = $parameters["ownPort"];
 $serviceAccount = $parameters["serviceAccount"];
@@ -92,6 +113,9 @@ if ($ownPort -eq "9090") {
 	(Get-Content $buildAgentDistFile) | Foreach-Object {
 		$_ -replace 'serverUrl=(?:\S+)', "serverUrl=$serverUrl" `
 		   -replace 'name=(?:\S+|$)', "name=$agentName"
+		   -replace 'workDir=(?:\S+|$)', "name=$agentWorkDir"
+		   -replace 'tempDir=(?:\S+|$)', "name=$agentTempDir"
+		   -replace 'systemDir=(?:\S+|$)', "name=$agentSystemDir"
 		} | Set-Content $buildAgentPropFile
 } else {
     # Since we are adding a new element and this can be tricky to get right
@@ -104,6 +128,9 @@ if ($ownPort -eq "9090") {
     # Set values that require customization
     $buildAgentProps['serverUrl'] = $serverUrl
     $buildAgentProps['name'] = $agentName
+    $buildAgentProps['workDir'] = $agentWorkDir
+    $buildAgentProps['tempDir'] = $agentTempDir
+    $buildAgentProps['systemDir'] = $agentSystemDir
     $buildAgentProps['ownPort'] = $ownPort
 
     Write-Verbose "Build Agent updated settings"


### PR DESCRIPTION
Handle settings for `workDir`, `tempDir` and `systemDir` in the TeamCity agent properties

Fix issue whereby if you don't include a `.\` for a local user the install fails.