### PR TITLE
Bump JDK dependency to Corretto 11

### DIFF
--- a/packages/TeamCityAgent/TeamCityAgent.nuspec
+++ b/packages/TeamCityAgent/TeamCityAgent.nuspec
@@ -18,7 +18,7 @@
         <releaseNotes>Version 3.x of this package uses AdoptOpenJDK. Version 4.x depends on Chocolatey 0.10.14.</releaseNotes>
         <tags>teamcity build agent ci continuous integration admin</tags>
         <dependencies>
-            <dependency id="corretto8jdk" version="8.252.09.1"/>
+            <dependency id="corretto11jdk" version="11.0.19"/>
         </dependencies>
     </metadata>
 </package>


### PR DESCRIPTION
https://www.jetbrains.com/help/teamcity/upgrade-notes.html#Planned+deprecation+of+Java+8+in+TeamCity+Server

JetBrains intends to move off Java 8 as a supported environment "soon".

This PR bumps the dependency here to Corretto 11, which should retain a high amount of compatibility.