### PR TITLE
Fix for TeamCity prop warning

### DIFF
--- a/packages/TeamCityAgent/tools/chocolateyInstall.ps1
+++ b/packages/TeamCityAgent/tools/chocolateyInstall.ps1
@@ -168,6 +168,7 @@ if (-Not ($defaultName -eq $true -And $defaultServiceAccount -eq $true)) {
     }
     if($serviceAccount -ne $null){
         $wrapperProps['wrapper.ntservice.account'] = "$serviceAccount"
+	$wrapperProps['wrapper.ntservice.interactive'] = "false"
     }
     if($serviceAccountPassword -ne $null){
         $wrapperProps['wrapper.ntservice.password'] = "$serviceAccountPassword"


### PR DESCRIPTION
When starting with this prop set as the default (true) you get a warning `Ignoring the wrapper.ntservice.interactive property because it can not be set when wrapper.ntservice.account is also set.` therefore setting it to false.